### PR TITLE
initial work for treasury history

### DIFF
--- a/src/formulas/formulas/contract/xion/treasury.ts
+++ b/src/formulas/formulas/contract/xion/treasury.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   Addr,
   FeeConfig,
   GrantConfig,
   Params,
 } from '@/formulas/formulas/contract/xion/types/Treasury.types'
-import { ContractFormula } from '@/types'
+import type { ContractFormula } from '@/types'
 
 import { makeSimpleContractFormula } from '../../utils'
 
@@ -86,6 +86,169 @@ export const balances: ContractFormula<Record<string, string>> = {
     const { contractAddress, getBalances } = env
 
     return (await getBalances(contractAddress)) || {}
+  },
+}
+
+export const history: ContractFormula<
+  {
+    treasury: {
+      address: string
+      params: Record<string, Params>
+      admin: Addr | null
+    }
+    transactions: Array<{
+      denom: string
+      balance: string
+      blockHeight: string
+      blockTimestamp: string
+      blockTimeUnixMs: string
+    }>
+    pagination: {
+      page: number
+      limit: number
+      total: number
+      totalPages: number
+      hasNext: boolean
+      hasPrev: boolean
+    }
+  },
+  {
+    page?: string
+    limit?: string
+    sortBy?: string
+    sortOrder?: string
+  }
+> = {
+  docs: {
+    description:
+      'Get historical transaction data for the treasury with pagination and sorting',
+    args: [
+      {
+        name: 'page',
+        description: 'Page number (default: 1)',
+        required: false,
+        schema: {
+          type: 'integer',
+          minimum: 1,
+        },
+      },
+      {
+        name: 'limit',
+        description: 'Items per page (default: 50, max: 1000)',
+        required: false,
+        schema: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 1000,
+        },
+      },
+      {
+        name: 'sortBy',
+        description: 'Sort field (blockHeight, denom, balance, blockTimestamp)',
+        required: false,
+        schema: {
+          type: 'string',
+          enum: ['blockHeight', 'denom', 'balance', 'blockTimestamp'],
+        },
+      },
+      {
+        name: 'sortOrder',
+        description: 'Sort direction (asc, desc)',
+        required: false,
+        schema: {
+          type: 'string',
+          enum: ['asc', 'desc'],
+        },
+      },
+    ],
+  },
+  dynamic: true, // Mark as dynamic for live data
+  compute: async (env) => {
+    const { contractAddress, query, args } = env
+
+    // Parse and validate arguments
+    const page = Math.max(1, Number.parseInt(args.page || '1', 10))
+    const limit = Math.min(
+      1000,
+      Math.max(1, Number.parseInt(args.limit || '50', 10))
+    )
+    const sortBy = args.sortBy || 'blockHeight'
+    const sortOrder = args.sortOrder || 'desc'
+    const offset = (page - 1) * limit
+
+    // Validate sort parameters
+    const validSortFields = [
+      'blockHeight',
+      'denom',
+      'balance',
+      'blockTimestamp',
+    ]
+    const validSortOrders = ['asc', 'desc']
+
+    if (!validSortFields.includes(sortBy)) {
+      throw new Error(
+        `Invalid sortBy field. Must be one of: ${validSortFields.join(', ')}`
+      )
+    }
+
+    if (!validSortOrders.includes(sortOrder)) {
+      throw new Error(
+        `Invalid sortOrder. Must be one of: ${validSortOrders.join(', ')}`
+      )
+    }
+
+    // Get treasury metadata
+    const [treasuryParams, treasuryAdmin] = await Promise.all([
+      params.compute(env),
+      admin.compute(env),
+    ])
+
+    // Get total count for pagination
+    const [{ count: totalCount }] = await query(
+      'SELECT COUNT(*) as "count" FROM "BankStateEvents" WHERE "address" = $1',
+      [contractAddress]
+    )
+
+    const total = Number(totalCount)
+    const totalPages = Math.ceil(total / limit)
+
+    // Get historical transactions with sorting and pagination
+    const transactions = await query(
+      `SELECT
+        "denom",
+        "balance",
+        "blockHeight",
+        "blockTimestamp",
+        "blockTimeUnixMs"
+      FROM "BankStateEvents"
+      WHERE "address" = $1
+      ORDER BY "${sortBy}" ${sortOrder.toUpperCase()}, "denom" ASC
+      LIMIT $2 OFFSET $3`,
+      [contractAddress, limit, offset]
+    )
+
+    return {
+      treasury: {
+        address: contractAddress,
+        params: treasuryParams,
+        admin: treasuryAdmin,
+      },
+      transactions: transactions.map((tx: Record<string, unknown>) => ({
+        denom: tx.denom as string,
+        balance: tx.balance as string,
+        blockHeight: tx.blockHeight as string,
+        blockTimestamp: tx.blockTimestamp as string,
+        blockTimeUnixMs: tx.blockTimeUnixMs as string,
+      })),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages,
+        hasNext: page < totalPages,
+        hasPrev: page > 1,
+      },
+    }
   },
 }
 

--- a/src/transformers/transformers/xion/treasury.ts
+++ b/src/transformers/transformers/xion/treasury.ts
@@ -1,8 +1,20 @@
-import { makeTransformer } from '../../utils'
+import { makeTransformer, makeTransformerForMap } from '../../utils'
 
 const CODE_IDS_KEYS = ['xion-treasury']
 
 const admin = makeTransformer(CODE_IDS_KEYS, 'admin')
+const params = makeTransformer(CODE_IDS_KEYS, 'params')
+const pendingAdmin = makeTransformer(
+  CODE_IDS_KEYS,
+  'pendingAdmin',
+  'pending_admin'
+)
+const feeConfig = makeTransformer(CODE_IDS_KEYS, 'feeConfig', 'fee_config')
+const grantConfigs = makeTransformerForMap(
+  CODE_IDS_KEYS,
+  'grantConfig',
+  'grant_configs'
+)
 
 // Export the transformers
-export default [admin]
+export default [admin, params, pendingAdmin, feeConfig, grantConfigs]

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -12612,6 +12612,92 @@
         }
       }
     },
+    "/{chainId}/contract/{contractAddress}/xion/treasury/history": {
+      "get": {
+        "tags": [
+          "contract"
+        ],
+        "summary": "Get historical transaction data for the treasury with pagination and sorting",
+        "operationId": "xion_treasury_history_e8a04c6",
+        "parameters": [
+          {
+            "name": "chainId",
+            "in": "path",
+            "description": "chain ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "contractAddress",
+            "in": "path",
+            "description": "contract address",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "description": "Page number (default: 1)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "in": "query"
+          },
+          {
+            "name": "limit",
+            "description": "Items per page (default: 50, max: 1000)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000
+            },
+            "in": "query"
+          },
+          {
+            "name": "sortBy",
+            "description": "Sort field (blockHeight, denom, balance, blockTimestamp)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "blockHeight",
+                "denom",
+                "balance",
+                "blockTimestamp"
+              ]
+            },
+            "in": "query"
+          },
+          {
+            "name": "sortOrder",
+            "description": "Sort direction (asc, desc)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "400": {
+            "description": "missing required arguments"
+          }
+        }
+      }
+    },
     "/{chainId}/contract/{contractAddress}/xion/treasury/params": {
       "get": {
         "tags": [


### PR DESCRIPTION
added transformer and formulas to display a treasury history with pagination.

how to run:

```bash
curl -X 'GET' \
  'http://localhost:3420/xion-testnet-2/contract/xion175qd54keur7gkuwtctfupgtucvlvkrxhv0pgq753sfh5xueputvsms6nll/xion/treasury/history' \
  -H 'accept: */*' | jq
```