### PR TITLE
Add migration for AccountDepositWebhookRegistrations table

### DIFF
--- a/src/db/migrations/20260411132020-create-account-deposit-webhook-registration.ts
+++ b/src/db/migrations/20260411132020-create-account-deposit-webhook-registration.ts
@@ -1,0 +1,79 @@
+import { QueryInterface, fn } from 'sequelize'
+import { DataType } from 'sequelize-typescript'
+
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.createTable('AccountDepositWebhookRegistrations', {
+      id: {
+        primaryKey: true,
+        autoIncrement: true,
+        type: DataType.INTEGER,
+      },
+      accountPublicKey: {
+        allowNull: false,
+        type: DataType.STRING,
+        references: {
+          model: 'Accounts',
+          key: 'publicKey',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      description: {
+        allowNull: true,
+        type: DataType.STRING,
+      },
+      endpointUrl: {
+        allowNull: false,
+        type: DataType.STRING,
+      },
+      authHeader: {
+        allowNull: true,
+        type: DataType.STRING,
+      },
+      authToken: {
+        allowNull: true,
+        type: DataType.STRING,
+      },
+      watchedWallets: {
+        allowNull: false,
+        type: DataType.ARRAY(DataType.STRING),
+        defaultValue: [],
+      },
+      allowedNativeDenoms: {
+        allowNull: false,
+        type: DataType.ARRAY(DataType.STRING),
+        defaultValue: [],
+      },
+      allowedCw20Contracts: {
+        allowNull: false,
+        type: DataType.ARRAY(DataType.STRING),
+        defaultValue: [],
+      },
+      enabled: {
+        allowNull: false,
+        type: DataType.BOOLEAN,
+        defaultValue: true,
+      },
+      createdAt: {
+        allowNull: false,
+        type: DataType.DATE,
+        defaultValue: fn('NOW'),
+      },
+      updatedAt: {
+        allowNull: false,
+        type: DataType.DATE,
+        defaultValue: fn('NOW'),
+      },
+    })
+    await queryInterface.addIndex('AccountDepositWebhookRegistrations', {
+      fields: ['accountPublicKey'],
+    })
+    await queryInterface.addIndex('AccountDepositWebhookRegistrations', {
+      fields: ['enabled'],
+    })
+  },
+  async down(queryInterface: QueryInterface) {
+    await queryInterface.dropTable('AccountDepositWebhookRegistrations')
+  },
+}


### PR DESCRIPTION
## Summary
- The `AccountDepositWebhookRegistration` model was added in the deposit-webhook work without a corresponding Sequelize migration, so fresh databases have no way to create the table.
- This adds a create-table migration mirroring the model (FK to `Accounts.publicKey` with cascade, string/array columns with `[]` defaults, `enabled` default true, timestamps, and indexes on `accountPublicKey` and `enabled`).

## Test plan
- [ ] `MIGRATING_DB=true npx sequelize-cli db:migrate` applies cleanly on a fresh DB
- [ ] `db:migrate:undo` rolls back cleanly
- [ ] Existing `AccountDepositWebhookRegistration` tests still pass against the migrated schema