### PR TITLE
feat: serve accounts and indexer APIs together

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,5 @@ RUN adduser --disabled-password --gecos "" argus
 RUN chown -R argus:argus /app
 USER argus
 
-# Default command to run the server
-CMD ["node", "dist/server/serve.js"]
+# Default command to run both the accounts and indexer APIs.
+CMD ["node", "dist/server/serve.js", "--both"]

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -11,13 +11,15 @@ import { setUpBullBoard } from './jobs'
 
 export type SetupRouterOptions = {
   config: Config
-  // Whether to run the account server. If false, runs indexer server.
+  // Whether to run the account server.
   accounts: boolean
+  // Whether to also run the indexer server in the same process.
+  both?: boolean
 }
 
 export const setUpRouter = async (
   app: Koa,
-  { config, accounts }: SetupRouterOptions
+  { config, accounts, both }: SetupRouterOptions
 ) => {
   const router = new Router()
 
@@ -40,7 +42,9 @@ export const setUpRouter = async (
   if (accounts) {
     // Account API.
     router.use(accountRouter.routes(), accountRouter.allowedMethods())
-  } else {
+  }
+
+  if (!accounts || both) {
     // Background jobs dashboard.
     await setUpBullBoard(app, config)
 

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -22,6 +22,7 @@ program.option(
   'path to config file, falling back to config.json'
 )
 program.option('-a, --accounts', 'run account server instead of indexer server')
+program.option('-b, --both', 'run both the account and indexer servers')
 program.parse()
 const options = program.opts()
 
@@ -29,6 +30,7 @@ const options = program.opts()
 const config = ConfigManager.load(options.config)
 
 const accounts = !!options.accounts
+const both = !!options.both
 
 // Setup app.
 const app = new Koa()
@@ -84,9 +86,9 @@ const main = async () => {
     type: DbType.Accounts,
   })
 
-  // Only connect to data if we're not serving the accounts API (i.e. we're
-  // serving indexer data).
-  if (!accounts) {
+  // Connect to data if serving the indexer API, either standalone or alongside
+  // the accounts API.
+  if (!accounts || both) {
     sequelize = await loadDb({
       type: DbType.Data,
     })
@@ -121,6 +123,7 @@ const main = async () => {
   await setUpRouter(app, {
     config,
     accounts,
+    both,
   })
 
   app.listen(options.port, () => {


### PR DESCRIPTION
## Summary
- add a `--both` server mode that mounts the accounts and indexer routers in one process
- load the data DB when serving both APIs so the indexer routes still function
- update the Docker image default command to start the server in `--both` mode

## Testing
- `npm run build:only`

## Context
The current image default starts `dist/server/serve.js` without `-a`, which only exposes the indexer API. This change makes the default container expose both the accounts API and the indexer API at the same time.