### PR TITLE
[codex] Inject docker build version into app

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -52,6 +52,8 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            APP_VERSION=${{ steps.meta.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM node:22-alpine
 
 WORKDIR /app
 
+ARG APP_VERSION
+ENV APP_VERSION=${APP_VERSION}
+
 # Copy package.json and package-lock.json first for better layer caching
 COPY package*.json ./
 COPY patches ./

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,12 +1,19 @@
 import { readFileSync } from 'fs'
 import { join } from 'path'
 
-// Read version from package.json at startup. Using readFileSync since this
-// runs once at import time, not per-request.
-// Use process.cwd() instead of __dirname since bundlers like tsup change
-// __dirname resolution, but cwd is reliably /app in Docker.
-const pkg = JSON.parse(
-  readFileSync(join(process.cwd(), 'package.json'), 'utf-8')
-)
+const injectedVersion = process.env.APP_VERSION?.trim()
+const packageVersion = () => {
+  // Read version from package.json at startup. Using readFileSync since this
+  // runs once at import time, not per-request.
+  // Use process.cwd() instead of __dirname since bundlers like tsup change
+  // __dirname resolution, but cwd is reliably /app in Docker.
+  const pkg = JSON.parse(
+    readFileSync(join(process.cwd(), 'package.json'), 'utf-8')
+  )
 
-export const version: string = pkg.version
+  return pkg.version as string
+}
+
+// Prefer the image/build-injected version when available so `/status`
+// reflects the published artifact version instead of the static repo file.
+export const version: string = injectedVersion || packageVersion()


### PR DESCRIPTION
## Summary
This follow-up fixes the app version reported by `/status` in published Docker images.

## What Changed
- prefer `APP_VERSION` over `package.json` in `src/version.ts`
- pass `APP_VERSION` into the runtime image via the Dockerfile
- wire the GitHub Actions Docker build to pass `steps.meta.outputs.version` as a build arg

## Why
The Docker workflow was correctly tagging and labeling published images with the Git ref version, but the app itself still read `package.json` inside the container. Since `package.json` had not been bumped, `/status` kept reporting `0.4.0` even in newer published images.

## Impact
After the next image build and deploy, `/status.version` should reflect the built artifact version instead of the stale repository package version.

## Validation
- `npm run build:only`

## Notes
This is intentionally a small follow-up to PR #10 so the version fix can merge and deploy independently.
