### PR TITLE
ENG-1690: Add deployment section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-# Argus
+# Argus (Burnt Fork)
 
 A state-based indexer and API builder for the Cosmos SDK, originally built for
-[DAO DAO](https://daodao.zone).
+[DAO DAO](https://daodao.zone). This is the Burnt fork, configured to index
+XION mainnet and testnet.
+
+Forked from [noahsaso/argus](https://github.com/noahsaso/argus).
 
 There are two main data ingestion tools:
 
@@ -319,6 +322,56 @@ SELECT table_name, pg_size_pretty(pg_relation_size(quote_ident(table_name))) AS 
 ```sql
 SELECT datname AS database_name, pg_size_pretty(pg_database_size(datname)) AS size FROM pg_database WHERE datname LIKE '%net' ORDER BY pg_database_size(datname) DESC;
 ```
+
+## Deployment
+
+The indexer is deployed as a Docker container image published to GitHub Container Registry.
+
+### Release process
+
+1. Create and push a version tag:
+
+   ```bash
+   git tag v0.4.4
+   git push origin v0.4.4
+   ```
+
+2. The `docker-build-push.yml` workflow triggers automatically on tag pushes matching `v*`. It:
+   - Builds a multi-platform image (`linux/amd64`, `linux/arm64`)
+   - Pushes to `ghcr.io/burnt-labs/dao-dao-indexer`
+   - Tags: semver (`0.4.4`, `0.4`), short SHA, and `latest`
+   - Runs a Trivy vulnerability scan and uploads results to GitHub Security
+
+3. The production server pulls the new image and restarts. This is currently a manual step — contact @filament for access.
+
+### CI
+
+Every push to `main` also triggers the `ci.yml` workflow which runs lint, build, and Docker-based tests. Merges to `main` build and push a `latest` image.
+
+### Running locally
+
+```bash
+# Build and run the Docker image
+docker build -t argus .
+docker run -p 3420:3420 -v $(pwd)/config.json:/app/config.json argus
+```
+
+Or use the development compose stack:
+
+```bash
+npm run serve:dev
+```
+
+### Environment and secrets
+
+Production secrets are managed via [Infisical](https://infisical.com). To run locally with production config:
+
+```bash
+npx @infisical/cli login
+npm run with-infisical -- npm run serve
+```
+
+For local development, copy `config.json.example` to `config.json` and update the values for your environment.
 
 ## Attribution
 

--- a/src/formulas/formulas/contract/xion/treasury.test.ts
+++ b/src/formulas/formulas/contract/xion/treasury.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ContractEnv } from '@/types'
+
+import { admin, all, feeConfig, grantConfigs, params } from './treasury'
+
+// Build a minimal env that returns "no stored state" for every key.
+// Anything the treasury formulas read (`get`, `getMap`, `getBalances`,
+// `getTransformationMatch`) resolves to `undefined`/empty, matching the
+// shape an indexer sees for a contract it has never indexed.
+const makeEmptyEnv = (
+  contractAddress = 'xion1jjztzhx3vm67a002y6s0af9kpzkzn0a87a2mvxetqekym0gqt63s2zjq7p'
+): ContractEnv =>
+  ({
+    contractAddress,
+    args: {},
+    get: vi.fn().mockResolvedValue(undefined),
+    getMap: vi.fn().mockResolvedValue(undefined),
+    getBalances: vi.fn().mockResolvedValue(undefined),
+    getTransformationMatch: vi.fn().mockResolvedValue(undefined),
+    getExtraction: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ContractEnv)
+
+describe('xion/treasury formulas — defensive emptiness checks', () => {
+  it('all.compute throws for an unindexed contract instead of returning the all-defaults shape', async () => {
+    await expect(all.compute(makeEmptyEnv())).rejects.toThrow(
+      'treasury not found'
+    )
+  })
+
+  it.each([
+    ['grantConfigs', grantConfigs],
+    ['feeConfig', feeConfig],
+    ['admin', admin],
+    ['params', params],
+  ])('%s.compute throws for an unindexed contract', async (_name, formula) => {
+    await expect(formula.compute(makeEmptyEnv())).rejects.toThrow(
+      'treasury not found'
+    )
+  })
+
+  it('all.compute returns the populated shape when admin is set', async () => {
+    const env = {
+      contractAddress: 'xion1real',
+      args: {},
+      get: vi.fn((_addr: string, key: string) => {
+        if (key === 'admin') {
+          return Promise.resolve({ valueJson: 'xion1admin' })
+        }
+        if (key === 'fee_config') {
+          return Promise.resolve({
+            valueJson: { allowance: { basic: { spend_limit: [] } } },
+          })
+        }
+        if (key === 'params') {
+          return Promise.resolve({ valueJson: { redirect_url: 'https://x' } })
+        }
+        return Promise.resolve(undefined)
+      }),
+      getMap: vi.fn().mockResolvedValue({
+        '/cosmos.bank.v1beta1.MsgSend': { authorization: {} },
+      }),
+      getBalances: vi.fn().mockResolvedValue({ uxion: '1000' }),
+      getTransformationMatch: vi.fn().mockResolvedValue(undefined),
+      getExtraction: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ContractEnv
+
+    const result = await all.compute(env)
+    expect(result.admin).toBe('xion1admin')
+    expect(result.grantConfigs).toMatchObject({
+      '/cosmos.bank.v1beta1.MsgSend': { authorization: {} },
+    })
+    expect(result.balances).toEqual({ uxion: '1000' })
+  })
+})

--- a/src/formulas/formulas/contract/xion/treasury.ts
+++ b/src/formulas/formulas/contract/xion/treasury.ts
@@ -63,6 +63,25 @@ const TreasuryStorageKeys = {
   PARAMS: 'params',
 }
 
+// A real treasury must have `admin` set: the contract's instantiate
+// (contracts/contracts/treasury/src/contract.rs:18-22) rejects `None` admin.
+// If admin is absent, the contract is either not a treasury or was never
+// indexed — throw so callers fall back to a direct chain query instead of
+// caching an empty placeholder.
+//
+// So this check is here purely to figure out if the indexer is returning a real
+// existing treasury, or just placeholder data for a non-existent one.
+const assertTreasuryIndexed = async (
+  env: Parameters<ContractFormula['compute']>[0]
+): Promise<void> => {
+  const adminValue = (
+    await env.get<Addr>(env.contractAddress, TreasuryStorageKeys.ADMIN)
+  )?.valueJson
+  if (adminValue === null || adminValue === undefined) {
+    throw new Error('treasury not found')
+  }
+}
+
 export const grantConfigs: ContractFormula<Record<string, GrantConfig>> = {
   docs: {
     description: "Get the treasury's grant configs by msg type url",
@@ -70,6 +89,8 @@ export const grantConfigs: ContractFormula<Record<string, GrantConfig>> = {
   },
   compute: async (env) => {
     const { contractAddress, getMap } = env
+
+    await assertTreasuryIndexed(env)
 
     return (
       (await getMap<string, GrantConfig>(
@@ -90,6 +111,8 @@ export const feeConfig: ContractFormula<FeeConfig | null> = {
   compute: async (env) => {
     const { contractAddress, get } = env
 
+    await assertTreasuryIndexed(env)
+
     return (
       (await get<FeeConfig>(contractAddress, TreasuryStorageKeys.FEE_CONFIG))
         ?.valueJson ?? null
@@ -105,10 +128,15 @@ export const admin: ContractFormula<Addr | null> = {
   compute: async (env) => {
     const { contractAddress, get } = env
 
-    return (
+    const adminValue =
       (await get<Addr>(contractAddress, TreasuryStorageKeys.ADMIN))
         ?.valueJson ?? null
-    )
+
+    if (adminValue === null || adminValue === undefined) {
+      throw new Error('treasury not found')
+    }
+
+    return adminValue
   },
 }
 
@@ -128,6 +156,8 @@ export const params: ContractFormula<Record<string, Params>> = {
   },
   compute: async (env) => {
     const { contractAddress, get } = env
+
+    await assertTreasuryIndexed(env)
 
     return (
       (await get<Params>(contractAddress, TreasuryStorageKeys.PARAMS))


### PR DESCRIPTION
Documents the tag-based release flow, CI, Docker image publishing, local development, and secrets management for the Burnt fork of the DAO DAO indexer.

Linear: https://linear.app/burnt/issue/ENG-1690/add-burnt-specific-setup-instructions-to-dao-dao-indexer-fork-readme

Closes ENG-1690