### PR TITLE
Remove upstream CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @noahsaso


### PR DESCRIPTION
The `CODEOWNERS` file points to `@noahsaso` (upstream maintainer), which doesn't apply to the Burnt fork. Removes it.